### PR TITLE
swap an append to innerHTML with a safer call to add adjacent html

### DIFF
--- a/index.html
+++ b/index.html
@@ -443,8 +443,8 @@ $(document).ready(function () {
 
 
 			  
-                document.getElementById('templateOneHere').innerHTML   += ourNewWord;
-                              
+                //document.getElementById('templateOneHere').innerHTML   += ourNewWord;
+				document.getElementById('templateOneHere').insertAdjacentHTML('beforeend',ourNewWord) ;          
                               
              
               


### PR DESCRIPTION
I'm swapping out one specific append to an innerHTML with a .insertAdjacentHTML() to prevent the "amount purchased" field from resetting.  

research:
https://betterprogramming.pub/dom-manipulation-the-dangers-of-innerhtml-602f4119d905
https://stackoverflow.com/questions/7327056/appending-html-string-to-the-dom/7327125

This is a first step.  Other uses should also probably be swapped.  And there may be some lingering security issues that should be addressed.  But, this change got me to the desired behavior of subsequent searches not resetting the value of the "amount purchased" field from previous items.